### PR TITLE
自動ビルドの設定変更

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -39,7 +39,7 @@ jobs:
       run: npm install -g firebase-tools
     - name: Deploy to Firebase Hosting
       run: |
-        firebase deploy --only hosting --token $FIREBASE_TOKEN --project $PROJECT_ID
+        firebase deploy --only hosting,firestore --force --token $FIREBASE_TOKEN --project $PROJECT_ID
       env:
         FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}
         PROJECT_ID: ${{ secrets.PROJECT_ID }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -43,3 +43,34 @@ jobs:
       env:
         FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}
         PROJECT_ID: ${{ secrets.PROJECT_ID }}
+    - name: Set COMMIT_MESSAGE
+      run: echo ::set-env name=COMMIT_MESSAGE::$(echo "${{ github.event.head_commit.message }}" | tr '\n' ' ')
+    - name: Slack Notification on SUCCESS
+      if: success()
+      uses: tokorom/action-slack-incoming-webhook@master
+      env:
+        INCOMING_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+      with:
+        text: ビルド成功です！やったね！
+        attachments: |
+          [
+            {
+              "color": "good",
+              "author_name": "${{ github.actor }}",
+              "author_icon": "${{ github.event.sender.avatar_url }}",
+              "fields": [
+                {
+                  "title": "Commit Message",
+                  "value": "${{ env.COMMIT_MESSAGE }}"
+                },
+                {
+                  "title": "GitHub Actions URL",
+                  "value": "${{ github.event.repository.url }}/actions/runs/${{ github.run_id }}"
+                },
+                {
+                  "title": "アプリURL",
+                  "value": "${{ secrets.APP_URL }}"
+                }
+              ]
+            }
+          ]


### PR DESCRIPTION
## 対応カード

https://trello.com/c/FAUPFQ6c
https://trello.com/c/ByF9tMib

## 対応したこと

- GitHub Actionsのデプロイ時に `Firestore` の `rules` と `index` を設定できるようにした
- ビルド成功時にSlack通知を飛ばすようにした(添付画像参照)
    - Slackの情報は `secrets` に定義しています


![スクリーンショット 2020-10-24 16 20 55](https://user-images.githubusercontent.com/7909367/97070711-81a30180-1615-11eb-9bf8-70143ce7eaa4.jpg)
